### PR TITLE
Add option for percentage-of-coverage in addition to -R

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,11 @@ Variant base must be found in `N` reads to be considered as present in sample
 (default: 3). This value should be above the expected number of base errors
 given the sequence coverage.
 
+#### `-F F, --var-fraction-min-reads F`
+Variant base must be found in fraction F of reads to be considered as present in
+sample. A minimum of reads can be set with the -R option for when this is low or
+can be low (default: 0.02)
+
 #### `-f F, --var-fraction F`
 Fraction of unique defining variants that must be observed to call a haplogroup
 present (default: 0.5). This value should be adjusted based on the likelihood

--- a/bin/mixemt
+++ b/bin/mixemt
@@ -430,17 +430,16 @@ def main():
     asm_opts.add_argument('-R', '--var-min-reads', dest='min_var_reads',
                           type=int, default=3, metavar='N',
                           help="Variant base must be found in N reads to be "
-                               "considered as present in sample. Can also be a "
-                               " default for the moments the amount from the percentage is to low "
+                               "considered as present in sample "
                                "(default: %(default)s)")
-
-    asm_opts.add_argument('-p', '--var-percentage-min-reads', dest='perc_var_reads',
+    asm_opts.add_argument('-p', '--var-percentage-min-reads',
+                          dest='perc_var_reads',
                           type=float, default=2., metavar='F',
-                          help="Variant base must be found in N percentage reads to be "
-                               "considered as present in sample. A minimum of reads can "
-                               "be set with the -R option for when this is low or can be low"
+                          help="Variant base must be found in F percent of "
+                               "reads to be considered as present in sample. "
+                               "A minimum of reads can be set with the -R "
+                               "option for when this is low or can be low "
                                "(default: %(default)s)")
-
     asm_opts.add_argument('-f', '--var-fraction', dest='var_fraction',
                           type=float, default=0.5, metavar='F',
                           help="Fraction of unique defining variants that "

--- a/bin/mixemt
+++ b/bin/mixemt
@@ -430,8 +430,17 @@ def main():
     asm_opts.add_argument('-R', '--var-min-reads', dest='min_var_reads',
                           type=int, default=3, metavar='N',
                           help="Variant base must be found in N reads to be "
-                               "considered as present in sample "
+                               "considered as present in sample. Can also be a "
+                               " default for the moments the amount from the percentage is to low "
                                "(default: %(default)s)")
+
+    asm_opts.add_argument('-p', '--var-percentage-min-reads', dest='perc_var_reads',
+                          type=float, default=2., metavar='F',
+                          help="Variant base must be found in N percentage reads to be "
+                               "considered as present in sample. A minimum of reads can "
+                               "be set with the -R option for when this is low or can be low"
+                               "(default: %(default)s)")
+
     asm_opts.add_argument('-f', '--var-fraction', dest='var_fraction',
                           type=float, default=0.5, metavar='F',
                           help="Fraction of unique defining variants that "

--- a/bin/mixemt
+++ b/bin/mixemt
@@ -432,10 +432,10 @@ def main():
                           help="Variant base must be found in N reads to be "
                                "considered as present in sample "
                                "(default: %(default)s)")
-    asm_opts.add_argument('-p', '--var-percentage-min-reads',
-                          dest='perc_var_reads',
-                          type=float, default=2., metavar='F',
-                          help="Variant base must be found in F percent of "
+    asm_opts.add_argument('-F', '--var-fraction-min-reads',
+                          dest='frac_var_reads',
+                          type=float, default=0.02, metavar='F',
+                          help="Variant base must be found in fraction F of "
                                "reads to be considered as present in sample. "
                                "A minimum of reads can be set with the -R "
                                "option for when this is low or can be low "

--- a/mixemt/assemble.py
+++ b/mixemt/assemble.py
@@ -142,8 +142,9 @@ def _check_contrib_phy_vars(phylo, obs_tab, contrib_prop, args):
         args: argparse Namespace with user specified values for:
             min_var_reads: The minimum number of observations required to call
                            a base as present in the mixture sample (int)
-            perc_var_reads: The minimum percentage of of observations required to call
-                           a base as present in the mixture sample (float)
+            perc_var_reads: The minimum percentage of observations required to
+                            call a base as present in the mixture sample
+                            (float)
             var_fraction: The minimum fraction of defining variants required
                           to be observed to call a haplogroup a contributor
                           (float)
@@ -169,7 +170,6 @@ def _check_contrib_phy_vars(phylo, obs_tab, contrib_prop, args):
             sys.stderr.write("%s (%d unique variants)\n"
                              % (hap, len(uniq_vars)))
 
-
         found_vars = set()
         for pos, der in sorted(uniq_vars):
             if args.verbose:
@@ -177,10 +177,8 @@ def _check_contrib_phy_vars(phylo, obs_tab, contrib_prop, args):
                 sys.stderr.write("  %s: %d/%d\n" % (var.rjust(6),
                                                     obs_tab.obs_at(pos, der),
                                                     obs_tab.total_obs(pos)))
-            threshold = (obs_tab.total_obs(pos) * args.perc_var_reads / 100)
-            if threshold < args.min_var_reads:
-                threshold = args.min_var_reads
-
+            threshold = max(args.min_var_reads,
+                            obs_tab.total_obs(pos) * args.perc_var_reads / 100)
             if obs_tab.obs_at(pos, der) >= threshold:
                 found_vars.add((pos, der))
         if ((len(uniq_vars) == 0)

--- a/mixemt/assemble.py
+++ b/mixemt/assemble.py
@@ -142,7 +142,7 @@ def _check_contrib_phy_vars(phylo, obs_tab, contrib_prop, args):
         args: argparse Namespace with user specified values for:
             min_var_reads: The minimum number of observations required to call
                            a base as present in the mixture sample (int)
-            perc_var_reads: The minimum percentage of observations required to
+            frac_var_reads: The minimum fraction of observations required to
                             call a base as present in the mixture sample
                             (float)
             var_fraction: The minimum fraction of defining variants required
@@ -177,8 +177,7 @@ def _check_contrib_phy_vars(phylo, obs_tab, contrib_prop, args):
                 sys.stderr.write("  %s: %d/%d\n" % (var.rjust(6),
                                                     obs_tab.obs_at(pos, der),
                                                     obs_tab.total_obs(pos)))
-            threshold = max(args.min_var_reads,
-                            obs_tab.total_obs(pos) * args.perc_var_reads / 100)
+            threshold = max(args.min_var_reads, obs_tab.total_obs(pos) * args.frac_var_reads)
             if obs_tab.obs_at(pos, der) >= threshold:
                 found_vars.add((pos, der))
         if ((len(uniq_vars) == 0)

--- a/mixemt/assemble.py
+++ b/mixemt/assemble.py
@@ -142,6 +142,8 @@ def _check_contrib_phy_vars(phylo, obs_tab, contrib_prop, args):
         args: argparse Namespace with user specified values for:
             min_var_reads: The minimum number of observations required to call
                            a base as present in the mixture sample (int)
+            perc_var_reads: The minimum percentage of of observations required to call
+                           a base as present in the mixture sample (float)
             var_fraction: The minimum fraction of defining variants required
                           to be observed to call a haplogroup a contributor
                           (float)
@@ -167,6 +169,7 @@ def _check_contrib_phy_vars(phylo, obs_tab, contrib_prop, args):
             sys.stderr.write("%s (%d unique variants)\n"
                              % (hap, len(uniq_vars)))
 
+
         found_vars = set()
         for pos, der in sorted(uniq_vars):
             if args.verbose:
@@ -174,7 +177,11 @@ def _check_contrib_phy_vars(phylo, obs_tab, contrib_prop, args):
                 sys.stderr.write("  %s: %d/%d\n" % (var.rjust(6),
                                                     obs_tab.obs_at(pos, der),
                                                     obs_tab.total_obs(pos)))
-            if obs_tab.obs_at(pos, der) >= args.min_var_reads:
+            threshold = (obs_tab.total_obs(pos) * args.perc_var_reads / 100)
+            if threshold < args.min_var_reads:
+                threshold = args.min_var_reads
+
+            if obs_tab.obs_at(pos, der) >= threshold:
                 found_vars.add((pos, der))
         if ((len(uniq_vars) == 0)
                 or (args.var_count is not None
@@ -186,7 +193,7 @@ def _check_contrib_phy_vars(phylo, obs_tab, contrib_prop, args):
                                  "%d/%d unique variant bases observed at "
                                  "least %d times.\n"
                                  % (hap, len(found_vars), len(uniq_vars),
-                                    args.min_var_reads))
+                                    threshold))
             # Looks good, these variants can't be used again.
             used_vars.update(found_vars)
             # Also add the ancestral bases for this haplogroup so we do not

--- a/mixemt/stats.py
+++ b/mixemt/stats.py
@@ -119,11 +119,9 @@ def write_variants(out, phylo, contribs, obs_tab, args):
         obs = obs_tab.obs_at(ref_pos)
 
         samp_status = "sample_fixed"
-        threshold = (obs_tab.total_obs(pos) * args.perc_var_reads / 100)
-        if threshold < args.min_var_reads:
-            threshold = args.min_var_reads
-
-        if sum([obs[base] >= threshold for base in 'ACGT']) > 1:
+        threshold = max(args.min_var_reads,
+                        obs_tab.total_obs(pos) * args.perc_var_reads / 100)
+        if sum(obs[base] >= threshold for base in 'ACGT') > 1:
             samp_status = "variant"
 
         phy_status = "fixed"

--- a/mixemt/stats.py
+++ b/mixemt/stats.py
@@ -119,8 +119,7 @@ def write_variants(out, phylo, contribs, obs_tab, args):
         obs = obs_tab.obs_at(ref_pos)
 
         samp_status = "sample_fixed"
-        threshold = max(args.min_var_reads,
-                        obs_tab.total_obs(pos) * args.perc_var_reads / 100)
+        threshold = max(args.min_var_reads, obs_tab.total_obs(pos) * args.frac_var_reads)
         if sum(obs[base] >= threshold for base in 'ACGT') > 1:
             samp_status = "variant"
 

--- a/mixemt/stats.py
+++ b/mixemt/stats.py
@@ -119,7 +119,11 @@ def write_variants(out, phylo, contribs, obs_tab, args):
         obs = obs_tab.obs_at(ref_pos)
 
         samp_status = "sample_fixed"
-        if sum([obs[base] >= args.min_var_reads for base in 'ACGT']) > 1:
+        threshold = (obs_tab.total_obs(pos) * args.perc_var_reads / 100)
+        if threshold < args.min_var_reads:
+            threshold = args.min_var_reads
+
+        if sum([obs[base] >= threshold for base in 'ACGT']) > 1:
             samp_status = "variant"
 
         phy_status = "fixed"

--- a/mixemt/test/assemble_test.py
+++ b/mixemt/test/assemble_test.py
@@ -25,7 +25,7 @@ class TestContributors(unittest.TestCase):
         self.args.verbose = False
         self.args.min_reads = 1
         self.args.min_var_reads = 1
-        self.args.perc_var_reads = 2.
+        self.args.frac_var_reads = 0.02
         self.args.var_fraction = 0.5
         self.args.var_count = None
         self.args.var_check = False

--- a/mixemt/test/assemble_test.py
+++ b/mixemt/test/assemble_test.py
@@ -25,6 +25,7 @@ class TestContributors(unittest.TestCase):
         self.args.verbose = False
         self.args.min_reads = 1
         self.args.min_var_reads = 1
+        self.args.perc_var_reads = 2.
         self.args.var_fraction = 0.5
         self.args.var_count = None
         self.args.var_check = False


### PR DESCRIPTION
This PR adds the -p/--var-percentage-min-reads option to Mixemt. Like the existing -R option, this option sets a threshold on the minimum number of reads that must contain a certain variant base before it is called present. The difference with the -R option is that this new option calculates the threshold as a percentage of the total coverage at the site of the variant.

Rationale: In our analyses we found that we sometimes have wildly varying coverage across the mtGenome. Setting the -R option too high would cause us to miss variants in the low-coverage regions, whereas setting it too low would cause us to pick up too much noise or low-level mixtures/heteroplasmy in the high-coverage regions. The new option circumvents this problem by making the threshold coverage-dependent.

The two options work together by selecting the higher of the two thresholds at each particular variant site.