### PR TITLE
Allow setting -i/--init to infinity for equal priors

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ some situations.
 
 #### `-i ALPHA, --init ALPHA`
 Use parameter `ALPHA` to initialize haplogroup contributions from Dirichlet
-distribution (default: 1.0)
+distribution. Set to 'inf' to give haplogroups equal priors. (default: 1.0)
 
 #### `-T TOLERANCE, --converge TOLERANCE`
 Stop EM iteration when absolute difference between current and previous

--- a/bin/mixemt
+++ b/bin/mixemt
@@ -394,7 +394,8 @@ def main():
     em_opts.add_argument('-i', '--init', dest='init_alpha', type=float,
                          default=1.0, metavar="ALPHA",
                          help="Use parameter ALPHA to initialize haplogroup "
-                              "contributions from Dirichlet distribution "
+                              "contributions from Dirichlet distribution. "
+                              "Set to 'inf' to give haplogroups equal priors. "
                               "(default: %(default)s)")
     em_opts.add_argument('-T', '--converge', dest='tolerance', type=float,
                          default=0.0001, metavar="TOLERANCE",

--- a/mixemt/em.py
+++ b/mixemt/em.py
@@ -31,6 +31,8 @@ def init_props(nhaps, alpha=1.0):
     Returns:
         a numpy array of random values that sum to 1.0
     """
+    if alpha == float("inf"):
+        return numpy.array([1.0 / nhaps] * nhaps)
     return numpy.random.dirichlet([alpha] * nhaps)
 
 


### PR DESCRIPTION
This PR explicitly adds support for setting the alpha parameter of the Dirichlet distribution with which the haplogroup contributions are initialized (the -i/--init option) to infinity. With alpha set to infinity, initially all haplogroups have contributed equally.

Rationale: I would like the results I get from Mixemt to be deterministic, but the use of a random set of initial contributions for the haplogroups currently makes this impossible. Those are sampled from a Dirichlet distribution with a configurable alpha parameter; setting that parameter to a high value will make the obtained initial contributions more alike. As alpha tends to infinity, the initial contributions would become equal, but due to the implementation of the distribution the actual result is `nan`. Therefore, this situation is dealt with explicitly.