### PR TITLE
Add option to set seed for random number generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ step where the mixture proportions are inferred. The default values should
 work well most of the time, but adjusting these values may be useful in
 some situations.
 
+#### `-S N --seed N`
+Use value `N` to seed the random number generator that generates starting
+mixture proportions. Allows `mixemt` to be run multiple times using the same
+input and produce the same results each time. If unset, the starting mixture
+proportions will differ with each run.
+
 #### `-i ALPHA, --init ALPHA`
 Use parameter `ALPHA` to initialize haplogroup contributions from Dirichlet
 distribution (default: 1.0)

--- a/bin/mixemt
+++ b/bin/mixemt
@@ -410,6 +410,9 @@ def main():
                          help="Runs EM until convergence multiple times and "
                               "reports the results averaged over all runs "
                               "(default: %(default)s)")
+    em_opts.add_argument('-S', '--seed', dest='seed', type=int, metavar='N',
+                         help="Sets the seed for random number generation "
+                              "for reproducible results.")
 
     asm_opts = parser.add_argument_group("contributor detection and "
                                          "assembly options")
@@ -491,6 +494,8 @@ def main():
 
     if args.verbose:
         sys.stderr.write('%s\n\n' % (' '.join(sys.argv)))
+    if args.seed:
+        numpy.random.seed(args.seed)
 
     return process_and_report(args)
 


### PR DESCRIPTION
Starting mixture proportions for expectation maximization are drawn at random. This option allows the user to set the seed for random number generation so that results can be reproduced in separate runs with the same seed number.

Addresses #16 and another solution for the reproducibility problem #18 addresses.